### PR TITLE
Fix issue where old GPU count not removed from OpenShiftSpawner.extra_resource_limits

### DIFF
--- a/.jupyter/jupyterhub_config.py
+++ b/.jupyter/jupyterhub_config.py
@@ -261,8 +261,8 @@ class OpenShiftSpawner(KubeSpawner):
     else:
         if self.extra_resource_guarantees and self.extra_resource_guarantees.get(GPU_KEY):
             del self.extra_resource_guarantees[GPU_KEY]
-        if self.extra_resource_guarantees and self.extra_resource_limit.get(GPU_KEY):
-            del self.extra_resource_limit[GPU_KEY]
+        if self.extra_resource_limits and self.extra_resource_limits.get(GPU_KEY):
+            del self.extra_resource_limits[GPU_KEY]
         self.privileged = False
 
     data = {} #'AWS_ACCESS_KEY_ID': formdata['AWS_ACCESS_KEY_ID'][0], 'AWS_SECRET_ACCESS_KEY': formdata['AWS_SECRET_ACCESS_KEY'][0]


### PR DESCRIPTION
Fix a condition where the GPU_KEY isn't removed from OpenShiftSpawner.extra_resource_limits when GPU_KEY is 0