### PR TITLE
Add GPU support for OCP4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 openshift
 jupyterhub-kubespawner==0.9.0
-git+https://github.com/vpavlin/jupyterhub-singleuser-profiles.git@625b1867dc425d87da8e4310920a576b593c23d2
+git+https://github.com/vpavlin/jupyterhub-singleuser-profiles.git@ca7f9ec9c11391f50143b559ab4ef63b7380c1b9
 git+https://github.com/vpavlin/jupyter-publish-extension.git@7cbf34e494fd9a0a79e9cd9a8c1d48a6775b9f49
 git+https://github.com/vpavlin/oauthenticator.git


### PR DESCRIPTION
JupyterHub now expects `GPU_MODE` env var (instead of `GPU_PRIVILEGED`) which can get 3 values 

* selinux
* privileged
* anything else -> None

`selinux` configures special Nvidia selinux policy, `privileged` makes the pod privileged to get access to GPUs and anything else will only request the GPU and let the cluster figure out the rest.

Depends on https://github.com/vpavlin/jupyterhub-singleuser-profiles/pull/10