### PR TITLE
Support customization of Jupyterhub admin users

### DIFF
--- a/.jupyter/jupyterhub_config.py
+++ b/.jupyter/jupyterhub_config.py
@@ -309,3 +309,6 @@ c.KubeSpawner.pvc_name_template = '%s-nb-{username}-pvc' % os.environ['JUPYTERHU
 c.KubeSpawner.volumes = [dict(name='data', persistentVolumeClaim=dict(claimName=c.KubeSpawner.pvc_name_template))]
 c.KubeSpawner.volume_mounts = [dict(name='data', mountPath='/opt/app-root/src')]
 c.KubeSpawner.user_storage_class = os.environ.get("JUPYTERHUB_STORAGE_CLASS", c.KubeSpawner.user_storage_class)
+admin_users = os.environ.get('JUPYTERHUB_ADMIN_USERS')
+if admin_users:
+    c.Authenticator.admin_users = set(admin_users.split(','))


### PR DESCRIPTION
This adds support for customizing the list of user IDs that should be granted admin access to JupyterHub via an environment variable, JUPYTERHUB_ADMIN_USERS