### PR TITLE
Update the kubespawner version to 0.11.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 openshift
-jupyterhub-kubespawner==0.9.0
+jupyterhub-kubespawner==0.11.1
 git+https://github.com/vpavlin/jupyterhub-singleuser-profiles.git@0bfb04b66cc4af35a6ad01b757d0986dcbccd980
 git+https://github.com/vpavlin/jupyter-publish-extension.git@7cbf34e494fd9a0a79e9cd9a8c1d48a6775b9f49
 git+https://github.com/vpavlin/oauthenticator.git


### PR DESCRIPTION
Update the kubespawner version to 0.11.1 with support for OCP 4.3 (Kubernetes 1.16) release.